### PR TITLE
Add GLUT library and headers to image

### DIFF
--- a/centos7/packages.txt
+++ b/centos7/packages.txt
@@ -37,6 +37,7 @@ lsof
 lzo-devel
 mesa-libGL-devel
 mesa-libGLU-devel
+freeglut-devel
 motif-devel
 MySQL-python
 nano


### PR DESCRIPTION
Needed to switch over the CI for, e.g. CED:

See, e.g. here: https://github.com/tmadlener/CED/runs/5589686771?check_suite_focus=true