### PR TITLE
Add ccache to EL9 and Ubuntu24 images

### DIFF
--- a/centos9/packages.txt
+++ b/centos9/packages.txt
@@ -3,6 +3,7 @@ automake
 bind-utils
 bzip2-devel
 bzip2
+ccache
 cmake
 cyrus-sasl-devel
 elfutils-devel

--- a/el9/packages.txt
+++ b/el9/packages.txt
@@ -3,6 +3,7 @@ automake
 bind-utils
 bzip2-devel
 bzip2
+ccache
 cmake
 cyrus-sasl-devel
 elfutils-devel

--- a/ubuntu2404/packages.txt
+++ b/ubuntu2404/packages.txt
@@ -41,6 +41,7 @@ bison
 byacc
 bzip2
 cmake
+ccache
 elfutils
 emacs
 flex


### PR DESCRIPTION
This would allow to use ccache for the run-lcg-view action (with corresponding updates there).